### PR TITLE
feat(golden-record): entity data model with temporal aliases (Issue #17)

### DIFF
--- a/src/graphhansard/golden_record/models.py
+++ b/src/graphhansard/golden_record/models.py
@@ -11,7 +11,6 @@ from typing import Annotated
 
 from pydantic import BaseModel, BeforeValidator, Field
 
-
 # ---------------------------------------------------------------------------
 # Date coercion: JSON stores ISO-8601 strings; we want datetime.date objects
 # ---------------------------------------------------------------------------
@@ -278,6 +277,6 @@ class GoldenRecord(BaseModel):
         result: list[MPNode] = []
         for mp in self.mps:
             alias_set = mp.aliases_on(query_date) if query_date else mp.all_aliases
-            if normalized in [a.lower() for a in alias_set]:
+            if any(a.lower() == normalized for a in alias_set):
                 result.append(mp)
         return result


### PR DESCRIPTION
## Summary

Implements **Issue #17 — GR: MP Entity Data Model & Canonical Records**, covering SRD requirements GR-1, GR-2, and GR-3.

- **Date parsing**: Portfolio dates are now coerced from ISO-8601 strings to `datetime.date` objects via a Pydantic `BeforeValidator`, enabling proper temporal comparisons
- **Computed aliases**: Each `MPNode` now generates constituency-based, portfolio-based, honorific, and formal name aliases at runtime — **412 total aliases** (up from 109 manual), exceeding the 357+ target
- **Temporal queries**: `GoldenRecord.who_held_portfolio(title, date)` and `resolve_alias_candidates(alias, date)` answer questions like *"Who held Minister of Works on 2023-08-01?"* using portfolio start/end dates and the Sept 3, 2023 reshuffle data

## Changes

### `src/graphhansard/golden_record/models.py`
| Addition | Purpose |
|----------|---------|
| `StrictDate` (Annotated type + `BeforeValidator`) | Coerce ISO strings → `datetime.date` on load |
| `PortfolioTenure.is_active_on(date)` | Check if a tenure was active on a given date |
| `MPNode.constituency_aliases` | "Member for X", "The Member for X" (78 aliases) |
| `MPNode.portfolio_aliases` | short_title, "The " + short_title, full title (116 aliases) |
| `MPNode.honorific_aliases` | "Hon. X", "The Honourable X" (78 aliases) |
| `MPNode.formal_name_aliases` | Full legal name (39 aliases) |
| `MPNode.all_aliases` | Deduplicated union of manual + all generated |
| `MPNode.portfolio_aliases_on(date)` | Temporally filtered portfolio aliases |
| `MPNode.aliases_on(date)` | Full alias set with temporal portfolio filtering |
| `GoldenRecord.who_held_portfolio(title, date)` | Find MPs holding a portfolio on a specific date |
| `GoldenRecord.resolve_alias_candidates(alias, date?)` | Case-insensitive alias lookup with optional temporal filter |
| `DeceasedMP.all_aliases` | Manual aliases for deceased MPs |

### `tests/test_golden_record.py`
Expanded from **5 → 21 tests** across 4 test classes:

| Class | Tests | Covers |
|-------|-------|--------|
| `TestGoldenRecordSchema` | 5 (existing) | Schema validation, party composition, Speaker node |
| `TestDateParsing` | 2 | Date coercion, null end_dates for current roles |
| `TestComputedAliases` | 7 | Alias count ≥ 357, constituency/honorific/portfolio/formal name generation, deduplication |
| `TestTemporalQueries` | 7 | `is_active_on`, `who_held_portfolio` before/after Sept 2023 reshuffle, `aliases_on` filtering, `resolve_alias_candidates` with/without date |

## Design decisions

- **Computed at runtime, not stored in JSON**: Generated aliases are `@property` methods on `MPNode`, keeping `mps.json` clean (only manual aliases) and avoiding duplication
- **`BeforeValidator` over `strict=True`**: Pydantic v2 strict mode would reject JSON strings as dates; the validator coerces them explicitly while keeping the JSON human-editable
- **Data-model-level resolution only**: `resolve_alias_candidates` does exact case-insensitive matching. Fuzzy matching (RapidFuzz) and the full resolution cascade are deferred to Issue #18 (Alias Resolution API)

## Test plan

- [x] All 21 tests pass: `PYTHONPATH=src pytest tests/test_golden_record.py -v`
- [x] Total computed aliases = 412 (≥ 357 threshold)
- [x] Temporal query verified: Sears → Minister of Works before reshuffle, Sweeting after
- [ ] Reviewer: confirm `mps.json` is unchanged (no data file modifications)
- [ ] Reviewer: confirm `resolver.py` is untouched (deferred to Issue #18)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)